### PR TITLE
优化图片显示

### DIFF
--- a/static/css/g.css
+++ b/static/css/g.css
@@ -14,6 +14,7 @@
 .fr{ float:right!important;}
 .fn{ float:none!important;}
 hr{height:0;-moz-box-sizing:content-box;box-sizing:content-box;margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #eee}
+img{max-width: 100%;height: auto;-webkit-box-shadow: #333 0px 0px 6px;-moz-box-shadow: #333 0px 0px 6px;box-shadow: #333 0px 0px 6px;}
 .img-circle{border-radius:50%}
 .cut-line {margin: 0 5px;color: #D6D6D6;}
 a{ color:#0066cc; text-decoration:none;}


### PR DESCRIPTION
1. 优化图片展示 最大宽度100%,以防过宽，影响排版 
2. 增加图片阴影效果
